### PR TITLE
Allow AddJPush with empty parameters

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -37,6 +37,7 @@ services.AddJPush(configuration);
   "MasterSecret": "Your MasterSecret"
 }
 ```
+> 您还可以直接调用 `AddJPush()` 而不传递任何参数，这样做需要在 `Startup.ConfigureServices` 方法中使用 `services.Configure<JPushOptions>(configuration)` 来配置 `JPushOptions`。
 
 然后，就可以愉快的使用 JPush 了😝。
 
@@ -53,4 +54,4 @@ public Constructor(JPushClient client)
 
  - 程序包版本v1.1.0对应 [Jiguang.Jpush](https://www.nuget.org/packages/Jiguang.JPush/) 的v1.1.0版本，以此类推。
  - 新版本 [Jiguang.JPush](https://www.nuget.org/packages/Jiguang.JPush/) 将由Azure Pipelines每月自动发布。
-- 若有某个版本未被实现，请提issue或直接联系我本人。
+ - 若有某个版本未被实现，请提issue或直接联系我本人。

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ If you use this way, you need to add a `whatever.json` file first, and with cont
 }
 ```
 
+> You can also just call `AddJPush()` without any parameters, by doing this, you need to configure `JPushOptions` with `services.Configure<JPushOptions>(configuration)` in `Startup.ConfigureServices` method.
+
 Now, you can use `JPushClient` in your classes.
 
 ```c#

--- a/src/Jiguang.JPush.Extensions/DependencyInjection/JPushServiceCollectionExtensions.cs
+++ b/src/Jiguang.JPush.Extensions/DependencyInjection/JPushServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ namespace Jiguang.JPush.DependencyInjection
     {
         /// <summary>
         /// 添加极光推送
+        /// 此方法需要在Startup中使用services.Configure<JPushOptions>(configuration)来配置JPushOptions
         /// </summary>
         /// <param name="services">The services.</param>
         /// <returns></returns>

--- a/src/Jiguang.JPush.Extensions/DependencyInjection/JPushServiceCollectionExtensions.cs
+++ b/src/Jiguang.JPush.Extensions/DependencyInjection/JPushServiceCollectionExtensions.cs
@@ -15,7 +15,7 @@ namespace Jiguang.JPush.DependencyInjection
         /// </summary>
         /// <param name="services">The services.</param>
         /// <returns></returns>
-        private static IJPushBuilder addJPush(this IServiceCollection services)
+        public static IJPushBuilder AddJPush(this IServiceCollection services)
         {
             IOptionsProvider oProvider = new OptionsProvider();
             IJPushBuilder builder = new JPushBuilder(services, oProvider);
@@ -34,7 +34,7 @@ namespace Jiguang.JPush.DependencyInjection
         public static IJPushBuilder AddJPush(this IServiceCollection services, Action<JPushOptions> setupAction)
         {
             services.Configure<JPushOptions>(setupAction);
-            return services.addJPush();
+            return services.AddJPush();
         }
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Jiguang.JPush.DependencyInjection
         public static IJPushBuilder AddJPush(this IServiceCollection services, IConfiguration configuration)
         {
             services.Configure<JPushOptions>(configuration);
-            return services.addJPush();
+            return services.AddJPush();
         }
     }
 }

--- a/src/Jiguang.JPush.Extensions/Jiguang.JPush.Extensions.csproj
+++ b/src/Jiguang.JPush.Extensions/Jiguang.JPush.Extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Authors>Weidaicheng</Authors>
     <Version>1.0.0</Version>
@@ -13,11 +13,12 @@
     <PackageVersion>1.2.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Jiguang.JPush" Version="1.2.0" />
+    <PackageReference Include="Jiguang.JPush" Version="1.2.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Jiguang.JPush.Extensions/Jiguang.JPush.Extensions.csproj
+++ b/src/Jiguang.JPush.Extensions/Jiguang.JPush.Extensions.csproj
@@ -9,8 +9,8 @@
     <PackageLicenseUrl>https://github.com/Weidaicheng/jpush-api-csharp-client.Extensions/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Weidaicheng/jpush-api-csharp-client.Extensions</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Weidaicheng/jpush-api-csharp-client.Extensions</RepositoryUrl>
-    <PackageReleaseNotes>v1.2.0 release</PackageReleaseNotes>
-    <PackageVersion>1.2.0</PackageVersion>
+    <PackageReleaseNotes>v1.2.5 release</PackageReleaseNotes>
+    <PackageVersion>1.2.5</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Jiguang.JPush" Version="1.2.5" />


### PR DESCRIPTION
1. Allow AddJPush with empty parameters. In this case, JPushOptions need to be registered in ConfigureServices method as following:
`services.Configure<JPushOptions>(configuration.GetSection("JPush"));`

2. Update the project target to `netstandard2.0`
